### PR TITLE
Custom Order By for Static Data Export

### DIFF
--- a/cmd/load_test.go
+++ b/cmd/load_test.go
@@ -1,7 +1,8 @@
 package cmd
 
 import (
-	"reflect"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 )
 
@@ -9,48 +10,48 @@ func Test_readStaticDataTablesFile(t *testing.T) {
 	type args struct {
 		filePath string
 	}
-	JsonTables := []string{"JsonTable1", "JsonTable2"}
-	TxtTables := []string{"TxtTable1", "TxtTable2"}
+	JsonTables := staticDataConfig{StaticDataTables: []string{"JsonTable1", "JsonTable2"}, CustomOrderBy: map[string]string{"JsonTable1": "Column1 ASC, Column2 DESC"}}
+	TxtTables := staticDataConfig{StaticDataTables: []string{"TxtTable1", "TxtTable2"}}
 	tests := []struct {
-		name       string
-		args       args
-		wantTables []string
-		wantErr    bool
+		name    string
+		args    args
+		wantSdc staticDataConfig
+		wantErr bool
 	}{
 		{
 			name: "default uses json first",
 			args: args{
 				filePath: "testdata/{wrench.json|static_data_tables.txt}",
 			},
-			wantTables: JsonTables,
+			wantSdc: JsonTables,
 		},
 		{
 			name: "default uses txt second",
 			args: args{
 				filePath: "testdata/txt/{wrench.json|static_data_tables.txt}",
 			},
-			wantTables: TxtTables,
+			wantSdc: TxtTables,
 		},
 		{
 			name: "specify json file",
 			args: args{
 				filePath: "testdata/wrench.json",
 			},
-			wantTables: JsonTables,
+			wantSdc: JsonTables,
 		},
 		{
 			name: "specify txt file",
 			args: args{
 				filePath: "testdata/static_data_tables.txt",
 			},
-			wantTables: TxtTables,
+			wantSdc: TxtTables,
 		},
 		{
 			name: "bad json path",
 			args: args{
 				filePath: "badpath/wrench.json",
 			},
-			wantTables: []string{},
+			wantSdc: staticDataConfig{},
 			wantErr: true,
 		},
 		{
@@ -58,20 +59,20 @@ func Test_readStaticDataTablesFile(t *testing.T) {
 			args: args{
 				filePath: "badpath/static_data_tables.txt",
 			},
-			wantTables: []string{},
+			wantSdc: staticDataConfig{},
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotTables, err := readStaticDataTablesFile(tt.args.filePath)
+			sdc, err := readStaticDataTablesFile(tt.args.filePath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("readStaticDataTablesFile() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(gotTables, tt.wantTables) {
-				t.Errorf("readStaticDataTablesFile() gotTables = %v, want %v", gotTables, tt.wantTables)
+			if !cmp.Equal(sdc, tt.wantSdc, cmpopts.EquateEmpty()) {
+				t.Errorf("readStaticDataTablesFile() sdc= %v, want %v", sdc, tt.wantSdc)
 			}
 		})
 	}

--- a/cmd/testdata/wrench.json
+++ b/cmd/testdata/wrench.json
@@ -3,6 +3,9 @@
     "JsonTable1",
     "JsonTable2"
   ],
+  "CustomOrderBy": {
+    "JsonTable1": "Column1 ASC, Column2 DESC"
+  },
   "Ignore other properties": {
     "other fields": 12345
   }


### PR DESCRIPTION
Support custom order by for static data. Currently the default is to order by Primary Key, but this may not result in a neat diff for append-only tables.