### PR TITLE
feat: identify some DML are not fully partitionable

### DIFF
--- a/pkg/spanner/migration.go
+++ b/pkg/spanner/migration.go
@@ -46,9 +46,10 @@ var (
 
 	dmlAnyRegex = regexp.MustCompile("^(UPDATE|DELETE|INSERT)[\t\n\f\r ].*")
 
-	// INSERT statements are not supported for partitioned DML. Although not every DML can be partitioned
+	// 1. INSERT statements are not supported for partitioned DML. Although not every DML can be partitioned
 	// as it must be idempotent. This probably isn't solvable with more regexes.
-	notPartitionedDmlRegex = regexp.MustCompile("INSERT")
+	// 2. UPDATE or DELETE statements with a SELECT statement in the WHERE clause is not fully partitionable.
+	notPartitionedDmlRegex = regexp.MustCompile(`(?is)(?:insert)|(?:update|delete).*select`)
 
 	// matches a single comment on its own line
 	oneLineSingleComment = regexp.MustCompile(`(?m)^\s*--.*$`)

--- a/pkg/spanner/migration_test.go
+++ b/pkg/spanner/migration_test.go
@@ -285,6 +285,11 @@ func Test_isPartitionedDMLOnly(t *testing.T) {
 			false,
 		},
 		{
+			"DELETE without SELECT is partitioned DML",
+			`DELETE FROM Singers WHERE SingerId = 123`,
+			true,
+		},
+		{
 			"DELETE statment with SELECT is not fully partitioned DML",
 			TestStmtNonPartitionedDML,
 			false,


### PR DESCRIPTION
## WHAT

Update the `notPartitionedDmlRegex` to include more non partitioned situations.

## WHY

Some non-partitionable DML are currently identified as partitionable DML.
For example,
```SQL
DELETE FROM User
WHERE UserID IN
(
  SELECT UserID
  FROM User
  INNER JOIN (
  ....)
);
```

