### PR TITLE
Bug: Fix NULL_FILTERED INDEX In DDL Parse Regex

### DIFF
--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -55,7 +55,7 @@ const (
 
 var (
 	createUpgradeIndicatorSql = fmt.Sprintf(createUpgradeIndicatorFormatString, upgradeIndicator)
-	indexOptions              = `unique\s+|null\s+filtered\s+|unique\s+null\s+filtered\s+`
+	indexOptions              = `unique\s+|null_filtered\s+|unique\s+null_filtered\s+`
 	ddlParse                  = regexp.MustCompile(`(?i)create\s+(?P<ObjectType>(table|(` + indexOptions + `)?index))\s+(?P<ObjectName>\w+).+`)
 )
 

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -673,10 +673,10 @@ func Test_parseDDL(t *testing.T) {
 			},
 		},
 		{
-			name: "CREATE NULL FILTERED INDEX",
-			args: args{"CREATE NULL FILTERED INDEX NFX_Example ON Example(ID)"},
+			name: "CREATE NULL_FILTERED INDEX",
+			args: args{"CREATE NULL_FILTERED INDEX NFX_Example ON Example(ID)"},
 			wantDdl: SchemaDDL{
-				Statement:  "CREATE NULL FILTERED INDEX NFX_Example ON Example(ID)",
+				Statement:  "CREATE NULL_FILTERED INDEX NFX_Example ON Example(ID)",
 				Filename:   "nfx_example.sql",
 				ObjectType: "index",
 			},
@@ -691,19 +691,19 @@ func Test_parseDDL(t *testing.T) {
 			},
 		},
 		{
-			name: "CREATE UNIQUE NULL FILTERED INDEX",
-			args: args{"CREATE UNIQUE NULL FILTERED INDEX UX_Example ON Example(ID)"},
+			name: "CREATE UNIQUE NULL_FILTERED INDEX",
+			args: args{"CREATE UNIQUE NULL_FILTERED INDEX UX_Example ON Example(ID)"},
 			wantDdl: SchemaDDL{
-				Statement:  "CREATE UNIQUE NULL FILTERED INDEX UX_Example ON Example(ID)",
+				Statement:  "CREATE UNIQUE NULL_FILTERED INDEX UX_Example ON Example(ID)",
 				Filename:   "ux_example.sql",
 				ObjectType: "index",
 			},
 		},
 		{
-			name: "CREATE		UNIQUE  NULL   	FILTERED   INDEX",
-			args: args{"CREATE\t\tUNIQUE  NULL   \tFILTERED   INDEX UX_Example ON Example(ID)"},
+			name: "CREATE		UNIQUE  NULL_FILTERED   INDEX",
+			args: args{"CREATE\t\tUNIQUE  NULL_FILTERED   INDEX UX_Example ON Example(ID)"},
 			wantDdl: SchemaDDL{
-				Statement:  "CREATE\t\tUNIQUE  NULL   \tFILTERED   INDEX UX_Example ON Example(ID)",
+				Statement:  "CREATE\t\tUNIQUE  NULL_FILTERED   INDEX UX_Example ON Example(ID)",
 				Filename:   "ux_example.sql",
 				ObjectType: "index",
 			},


### PR DESCRIPTION
## WHAT

Replaces regex that looks for `NULL FILTERED INDEX` with `NULL_FILTERED INDEX`

## WHY

`NULL_FILTERED` is the correct parameter

https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#create-index
