### PR TITLE
ANZX-146383 - Adding Verbose command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ Flags:
       --directory string                 Directory that schema file placed (required)
   -h, --help                             help for wrench
       --instance string                  Cloud Spanner instance name (optional. if not set, will use $SPANNER_INSTANCE_ID value)
-      --lock-identifier string           Random identifier used to lock migration operations to a single wrench process. (optional. if not set then it will be generated) (default "58a4394a-19f9-4dbf-880d-20b6cf169d46")
+      --lock-identifier string           Random identifier used to lock migration operations to a single wrench process. (optional. if not set then it will be generated) (default "e00245e9-2bb5-4409-98a5-795939ce491e")
       --project string                   GCP project id (optional. if not set, will use $SPANNER_PROJECT_ID or $GOOGLE_CLOUD_PROJECT value)
       --schema-file string               Name of schema file (optional. if not set, will use default 'schema.sql' file name)
       --sequence-interval uint16         Used to generate the next migration id. Rounds up to the next interval. (optional. if not set, will use $WRENCH_SEQUENCE_INTERVAL or default to 1) (default 1)
       --static-data-tables-file string   File containing list of static data tables to track (optional)
+      --verbose                          Used to indicate whether to output Migration information during a migration
   -v, --version                          version for wrench
 
 Use "wrench [command] --help" for more information about a command.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Flags:
       --directory string                 Directory that schema file placed (required)
   -h, --help                             help for wrench
       --instance string                  Cloud Spanner instance name (optional. if not set, will use $SPANNER_INSTANCE_ID value)
-      --lock-identifier string           Random identifier used to lock migration operations to a single wrench process. (optional. if not set then it will be generated) (default "e00245e9-2bb5-4409-98a5-795939ce491e")
+      --lock-identifier string           Random identifier used to lock migration operations to a single wrench process. (optional. if not set then it will be generated) (default "58a4394a-19f9-4dbf-880d-20b6cf169d46")
       --project string                   GCP project id (optional. if not set, will use $SPANNER_PROJECT_ID or $GOOGLE_CLOUD_PROJECT value)
       --schema-file string               Name of schema file (optional. if not set, will use default 'schema.sql' file name)
       --sequence-interval uint16         Used to generate the next migration id. Rounds up to the next interval. (optional. if not set, will use $WRENCH_SEQUENCE_INTERVAL or default to 1) (default 1)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -40,6 +40,7 @@ const (
 	flagNameSchemaFile          = "schema-file"
 	flagLockIdentifier          = "lock-identifier"
 	flagSequenceInterval        = "sequence-interval"
+	flagVerbose                 = "verbose"
 	flagDDLFile                 = "ddl"
 	flagDMLFile                 = "dml"
 	flagPartitioned             = "partitioned"

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -211,17 +211,30 @@ func migrateUp(c *cobra.Command, args []string) error {
 			err: err,
 		}
 	}
+
+	var migrationsOutput spanner.MigrationsOutput
 	switch status {
 	case spanner.ExistingMigrationsUpgradeStarted:
-		return client.UpgradeExecuteMigrations(ctx, migrations, limit, migrationTableName)
+		migrationsOutput, err = client.UpgradeExecuteMigrations(ctx, migrations, limit, migrationTableName)
+		if err != nil {
+			return err
+		}
 	case spanner.ExistingMigrationsUpgradeCompleted:
-		return client.ExecuteMigrations(ctx, migrations, limit, migrationTableName)
+		migrationsOutput, err = client.ExecuteMigrations(ctx, migrations, limit, migrationTableName)
+		if err != nil {
+			return err
+		}
 	default:
 		return &Error{
 			cmd: c,
 			err: errors.New("migration in undetermined state"),
 		}
 	}
+	if verbose {
+		fmt.Print(migrationsOutput.String())
+	}
+
+	return nil
 }
 
 func migrateVersion(c *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ var (
 	staticDataTablesFile string
 	lockIdentifier       string
 	sequenceInterval     uint16
+	verbose              bool
 )
 
 var rootCmd = &cobra.Command{
@@ -84,6 +85,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&staticDataTablesFile, flagStaticDataTablesFile, "", "File containing list of static data tables to track (optional)")
 	rootCmd.PersistentFlags().StringVar(&lockIdentifier, flagLockIdentifier, getLockIdentifier(), "Random identifier used to lock migration operations to a single wrench process. (optional. if not set then it will be generated)")
 	rootCmd.PersistentFlags().Uint16Var(&sequenceInterval, flagSequenceInterval, getSequenceInterval(), "Used to generate the next migration id. Rounds up to the next interval. (optional. if not set, will use $WRENCH_SEQUENCE_INTERVAL or default to 1)")
+	rootCmd.PersistentFlags().BoolVar(&verbose, flagVerbose, false, "Used to indicate whether to output Migration information during a migration")
 
 	rootCmd.Version = versioninfo.Version
 	rootCmd.SetVersionTemplate(versionTemplate)

--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -633,11 +633,16 @@ func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, l
 				}
 			}
 		case statementKindDML:
-			if _, err := c.ApplyDML(ctx, m.Statements); err != nil {
+			rowsAffected, err := c.ApplyDML(ctx, m.Statements)
+			if err != nil {
 				return nil, &Error{
 					Code: ErrorCodeExecuteMigrations,
 					err:  err,
 				}
+			}
+
+			migrationsOutput[m.FileName] = migrationInfo{
+				RowsAffected: rowsAffected,
 			}
 		case statementKindPartitionedDML:
 			rowsAffected, err := c.ApplyPartitionedDML(ctx, m.Statements)

--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -570,7 +570,7 @@ func (i MigrationsOutput) String() string {
 		output = fmt.Sprintf("%s\n%s - rows affected: %d", output, filename, migrationInfo.RowsAffected)
 	}
 
-	return output
+	return fmt.Sprintf("%s\n", output)
 }
 
 func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, limit int, tableName string) (MigrationsOutput, error) {

--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -446,18 +446,23 @@ func (c *Client) ApplyPartitionedDML(ctx context.Context, statements []string) (
 	return numAffectedRows, nil
 }
 
-func (c *Client) UpgradeExecuteMigrations(ctx context.Context, migrations Migrations, limit int, tableName string) error {
+func (c *Client) UpgradeExecuteMigrations(ctx context.Context, migrations Migrations, limit int, tableName string) (MigrationsOutput, error) {
 	err := c.backfillMigrations(ctx, migrations, tableName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	err = c.ExecuteMigrations(ctx, migrations, limit, tableName)
+	migrationsOutput, err := c.ExecuteMigrations(ctx, migrations, limit, tableName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return c.markUpgradeComplete(ctx)
+	err = c.markUpgradeComplete(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return migrationsOutput, nil
 }
 
 func (c *Client) backfillMigrations(ctx context.Context, migrations Migrations, tableName string) error {
@@ -549,14 +554,33 @@ func (c *Client) GetMigrationHistory(ctx context.Context, versionTableName strin
 	return history, nil
 }
 
-func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, limit int, tableName string) error {
+type MigrationsOutput map[string]migrationInfo
+
+type migrationInfo struct {
+	RowsAffected int64
+}
+
+func (i MigrationsOutput) String() string {
+	if len(i) == 0 {
+		return ""
+	}
+
+	output := "Migration Information:"
+	for filename, migrationInfo := range i {
+		output = fmt.Sprintf("%s\n%s - rows affected: %d", output, filename, migrationInfo.RowsAffected)
+	}
+
+	return output
+}
+
+func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, limit int, tableName string) (MigrationsOutput, error) {
 	sort.Sort(migrations)
 
 	version, dirty, err := c.GetSchemaMigrationVersion(ctx, tableName)
 	if err != nil {
 		var se *Error
 		if !errors.As(err, &se) || se.Code != ErrorCodeNoMigration {
-			return &Error{
+			return nil, &Error{
 				Code: ErrorCodeExecuteMigrations,
 				err:  err,
 			}
@@ -564,15 +588,15 @@ func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, l
 	}
 
 	if dirty {
-		return &Error{
+		return nil, &Error{
 			Code: ErrorCodeMigrationVersionDirty,
-			err:  fmt.Errorf("Database version: %d is dirty, please fix it.", version),
+			err:  fmt.Errorf("database version: %d is dirty, please fix it.", version),
 		}
 	}
 
 	history, err := c.GetMigrationHistory(ctx, tableName)
 	if err != nil {
-		return &Error{
+		return nil, &Error{
 			Code: ErrorCodeExecuteMigrations,
 			err:  err,
 		}
@@ -582,6 +606,7 @@ func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, l
 		applied[history[i].Version] = true
 	}
 
+	var migrationsOutput MigrationsOutput = make(MigrationsOutput)
 	var count int
 	for _, m := range migrations {
 		if limit == 0 {
@@ -593,7 +618,7 @@ func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, l
 		}
 
 		if err := c.setSchemaMigrationVersion(ctx, m.Version, true, tableName); err != nil {
-			return &Error{
+			return nil, &Error{
 				Code: ErrorCodeExecuteMigrations,
 				err:  err,
 			}
@@ -602,27 +627,32 @@ func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, l
 		switch m.kind {
 		case statementKindDDL:
 			if err := c.ApplyDDL(ctx, m.Statements); err != nil {
-				return &Error{
+				return nil, &Error{
 					Code: ErrorCodeExecuteMigrations,
 					err:  err,
 				}
 			}
 		case statementKindDML:
 			if _, err := c.ApplyDML(ctx, m.Statements); err != nil {
-				return &Error{
+				return nil, &Error{
 					Code: ErrorCodeExecuteMigrations,
 					err:  err,
 				}
 			}
 		case statementKindPartitionedDML:
-			if _, err := c.ApplyPartitionedDML(ctx, m.Statements); err != nil {
-				return &Error{
+			rowsAffected, err := c.ApplyPartitionedDML(ctx, m.Statements)
+			if err != nil {
+				return nil, &Error{
 					Code: ErrorCodeExecuteMigrations,
 					err:  err,
 				}
 			}
+
+			migrationsOutput[m.FileName] = migrationInfo{
+				RowsAffected: rowsAffected,
+			}
 		default:
-			return &Error{
+			return nil, &Error{
 				Code: ErrorCodeExecuteMigrations,
 				err:  fmt.Errorf("Unknown query type, version: %d", m.Version),
 			}
@@ -635,7 +665,7 @@ func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, l
 		}
 
 		if err := c.setSchemaMigrationVersion(ctx, m.Version, false, tableName); err != nil {
-			return &Error{
+			return nil, &Error{
 				Code: ErrorCodeExecuteMigrations,
 				err:  err,
 			}
@@ -651,7 +681,7 @@ func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, l
 		fmt.Println("no change")
 	}
 
-	return nil
+	return migrationsOutput, nil
 }
 
 func (c *Client) GetSchemaMigrationVersion(ctx context.Context, tableName string) (uint, bool, error) {

--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -565,8 +565,16 @@ func (i MigrationsOutput) String() string {
 		return ""
 	}
 
+	var filenames []string
+	for filename := range i {
+		filenames = append(filenames, filename)
+	}
+
+	sort.StringSlice(filenames).Sort()
+
 	output := "Migration Information:"
-	for filename, migrationInfo := range i {
+	for _, filename := range filenames {
+		migrationInfo := i[filename]
 		output = fmt.Sprintf("%s\n%s - rows affected: %d", output, filename, migrationInfo.RowsAffected)
 	}
 

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -803,19 +803,19 @@ func Test_MigrationInfoString(t *testing.T) {
 			exptectedOutput: "Migration Information:\ni-deleted-everything.sql - rows affected: 2000\n",
 		},
 		{
-			testName: "many result",
+			testName: "many results",
 			migrationInfo: MigrationsOutput{
-				"i-am-a-cool-update.sql": migrationInfo{
+				"0001-i-am-a-cool-update.sql": migrationInfo{
 					RowsAffected: 20,
 				},
-				"not-as-cool-as-me.sql": migrationInfo{
+				"0002-not-as-cool-as-me.sql": migrationInfo{
 					RowsAffected: 25,
 				},
-				"i-deleted-everything.sql": migrationInfo{
+				"0003-i-deleted-everything.sql": migrationInfo{
 					RowsAffected: 2000,
 				},
 			},
-			exptectedOutput: "Migration Information:\ni-am-a-cool-update.sql - rows affected: 20\nnot-as-cool-as-me.sql - rows affected: 25\ni-deleted-everything.sql - rows affected: 2000\n",
+			exptectedOutput: "Migration Information:\n0001-i-am-a-cool-update.sql - rows affected: 20\n0002-not-as-cool-as-me.sql - rows affected: 25\n0003-i-deleted-everything.sql - rows affected: 2000\n",
 		},
 	}
 

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -210,9 +210,14 @@ func TestExecuteMigrations(t *testing.T) {
 		t.Fatalf("failed to load migrations: %v", err)
 	}
 
+	var migrationsOutput MigrationsOutput
 	// only apply 000002.sql by specifying limit 1.
-	if err := client.ExecuteMigrations(ctx, migrations, 1, migrationTable); err != nil {
+	if migrationsOutput, err = client.ExecuteMigrations(ctx, migrations, 1, migrationTable); err != nil {
 		t.Fatalf("failed to execute migration: %v", err)
+	}
+
+	if len(migrationsOutput) != 0 {
+		t.Errorf("want zero length migrationInfo, but got %v", len(migrationsOutput))
 	}
 
 	// ensure that only 000002.sql has been applied.
@@ -220,8 +225,12 @@ func TestExecuteMigrations(t *testing.T) {
 	ensureMigrationVersionRecord(t, ctx, client, 2, false)
 	ensureMigrationHistoryRecord(t, ctx, client, 2, false)
 
-	if err := client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable); err != nil {
+	if migrationsOutput, err = client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable); err != nil {
 		t.Fatalf("failed to execute migration: %v", err)
+	}
+
+	if want, got := int64(1), migrationsOutput["000003.sql"].RowsAffected; want != got {
+		t.Errorf("want %d, but got %d", want, got)
 	}
 
 	// ensure that 000003.sql and 000004.sql have been applied.
@@ -499,7 +508,7 @@ func TestHotfixMigration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load migrations: %v", err)
 	}
-	if err := client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable); err != nil {
+	if _, err = client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable); err != nil {
 		t.Fatalf("failed to execute migration: %v", err)
 	}
 	history, err := client.GetMigrationHistory(ctx, migrationTable)
@@ -517,7 +526,7 @@ func TestHotfixMigration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load migrations: %v", err)
 	}
-	if err := client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable); err != nil {
+	if _, err := client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable); err != nil {
 		t.Fatalf("failed to execute migration: %v", err)
 	}
 	history, err = client.GetMigrationHistory(ctx, migrationTable)
@@ -541,7 +550,7 @@ func TestUpgrade(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to load migrations: %v", err)
 		}
-		if err := client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable); err != nil {
+		if _, err := client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable); err != nil {
 			t.Fatalf("failed to execute migration: %v", err)
 		}
 		expected, err := client.GetMigrationHistory(ctx, migrationTable)
@@ -559,7 +568,7 @@ func TestUpgrade(t *testing.T) {
 		if client.tableExists(ctx, upgradeIndicator) == false {
 			t.Error("upgrade indicator should exist")
 		}
-		if err := client.UpgradeExecuteMigrations(ctx, migrations, len(migrations), migrationTable); err != nil {
+		if _, err := client.UpgradeExecuteMigrations(ctx, migrations, len(migrations), migrationTable); err != nil {
 			t.Fatalf("failed to execute migration: %v", err)
 		}
 
@@ -769,11 +778,64 @@ func TestClient_RepairMigration(t *testing.T) {
 	}
 }
 
+func Test_MigrationInfoString(t *testing.T) {
+	tests := []struct {
+		testName        string
+		migrationInfo   MigrationsOutput
+		exptectedOutput string
+	}{
+		{
+			testName:        "no results",
+			migrationInfo:   MigrationsOutput{},
+			exptectedOutput: "",
+		},
+		{
+			testName:        "unitiated results - panic resiliant",
+			exptectedOutput: "",
+		},
+		{
+			testName: "one result",
+			migrationInfo: MigrationsOutput{
+				"i-deleted-everything.sql": migrationInfo{
+					RowsAffected: 2000,
+				},
+			},
+			exptectedOutput: "Migration Information:\ni-deleted-everything.sql - rows affected: 2000",
+		},
+		{
+			testName: "many result",
+			migrationInfo: MigrationsOutput{
+				"i-am-a-cool-update.sql": migrationInfo{
+					RowsAffected: 20,
+				},
+				"not-as-cool-as-me.sql": migrationInfo{
+					RowsAffected: 25,
+				},
+				"i-deleted-everything.sql": migrationInfo{
+					RowsAffected: 2000,
+				},
+			},
+			exptectedOutput: "Migration Information:\ni-am-a-cool-update.sql - rows affected: 20\nnot-as-cool-as-me.sql - rows affected: 25\ni-deleted-everything.sql - rows affected: 2000",
+		},
+	}
+
+	for _, test := range tests {
+		output := test.migrationInfo.String()
+		assert.Equal(t, test.exptectedOutput, output)
+	}
+}
+
 func migrateUpDir(t *testing.T, ctx context.Context, client *Client, dir string, toSkip ...uint) error {
 	t.Helper()
 	migrations, err := LoadMigrations(dir, toSkip)
 	if err != nil {
 		return err
 	}
-	return client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable)
+
+	_, err = client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -800,7 +800,7 @@ func Test_MigrationInfoString(t *testing.T) {
 					RowsAffected: 2000,
 				},
 			},
-			exptectedOutput: "Migration Information:\ni-deleted-everything.sql - rows affected: 2000",
+			exptectedOutput: "Migration Information:\ni-deleted-everything.sql - rows affected: 2000\n",
 		},
 		{
 			testName: "many result",
@@ -815,7 +815,7 @@ func Test_MigrationInfoString(t *testing.T) {
 					RowsAffected: 2000,
 				},
 			},
-			exptectedOutput: "Migration Information:\ni-am-a-cool-update.sql - rows affected: 20\nnot-as-cool-as-me.sql - rows affected: 25\ni-deleted-everything.sql - rows affected: 2000",
+			exptectedOutput: "Migration Information:\ni-am-a-cool-update.sql - rows affected: 20\nnot-as-cool-as-me.sql - rows affected: 25\ni-deleted-everything.sql - rows affected: 2000\n",
 		},
 	}
 

--- a/pkg/spanner/migration.go
+++ b/pkg/spanner/migration.go
@@ -70,6 +70,9 @@ type (
 		// Name is the name of the migration
 		Name string
 
+		// FileName is the name of the source file for the migration
+		FileName string
+
 		// Statements is the migration statements
 		Statements []string
 
@@ -138,6 +141,7 @@ func LoadMigrations(dir string, toSkipSlice []uint) (Migrations, error) {
 		migrations = append(migrations, &Migration{
 			Version:    uint(version),
 			Name:       matches[2],
+			FileName:   f.Name(),
 			Statements: statements,
 			kind:       kind,
 		})


### PR DESCRIPTION
## WHAT
This PR adds a new _versbose_ command to the wrench repository. When this command is provided during a migration where a spanner UPDATE, DELETE, INSERT occurrs, the program will output the migration filename which performed the change + the number of rows affected.
The output will look something like:
`
Migration Information:
000003_update_customers.sql - rows affected 5
000006_delete_contacts.sql - rows affected 50
`

## WHY

Our team is needing output regarding how many rows were updating during a migration. This would provide visibility over the success of an update, and will give us a quick indication of success/failure of the update.

<img width="1388" alt="Screenshot 2024-03-07 at 2 45 43 pm" src="https://github.com/RoryQ/wrench/assets/129822141/9f183203-6055-4bb5-b712-8cdbcba8ab5d">

