### PR TITLE
Fix Schema Migration Version Reverted To After Repair

### DIFF
--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -841,7 +841,7 @@ func (c *Client) RepairMigration(ctx context.Context, tableName string) error {
 }
 
 func resetSchemaVersion(ctx context.Context, tx *spanner.ReadWriteTransaction, tableNameHistory string, tableName string) ([]*spanner.Mutation, error) {
-	latestSQL := "select * from " + tableNameHistory + " where dirty = FALSE order by version limit 1"
+	latestSQL := "select * from " + tableNameHistory + " where dirty = FALSE order by version desc limit 1"
 	latest, err := spannerz.GetSQL[MigrationHistoryRecord](ctx, tx, latestSQL)
 	if err != nil {
 		return nil, err

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -756,7 +756,6 @@ func Test_parseDDL(t *testing.T) {
 
 func TestClient_RepairMigration(t *testing.T) {
 	ctx := context.Background()
-
 	client, done := testClientWithDatabase(t, ctx)
 	defer done()
 


### PR DESCRIPTION
## WHAT

Calling "repair" currently reverts to the first non-dirty version in the migration history table, rather than the latest.

This PR fixes this to revert to the latest non-dirty version.

## WHY

Subsequent migrations will run from the beginning, rather than the latest clean version.