### PR TITLE
propagate connection placeholders to schema

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -100,7 +100,7 @@ func init() {
 
 	migrateCreateCmd.Flags().Bool(flagNameCreateNoPrompt, false, "Don't prompt for a migration file description")
 	migrateUpCmd.Flags().UintSlice(flagSkipVersions, []uint{}, "Versions to skip during migration")
-	migrateUpCmd.Flags().Bool(flagPlaceholderReplacement, false, "Enable placeholder replacement for ${PROJECT_ID}, ${INSTANCE_ID} and ${DATABASE_ID}")
+	migrateUpCmd.Flags().Bool(flagPlaceholderReplacement, true, "Enable placeholder replacement for ${PROJECT_ID}, ${INSTANCE_ID} and ${DATABASE_ID}")
 }
 
 func migrateCreate(c *cobra.Command, args []string) error {

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -17,6 +17,8 @@ func Test_schema(t *testing.T) {
 	// execute schema command
 	cmd := schemaCmd
 	_ = cmd.Flag(flagNameDirectory).Value.Set("testdata/schema_test")
+	_ = cmd.Flag(flagNameProject).Value.Set("test-project")
+	_ = cmd.Flag(flagNameInstance).Value.Set("my-instance")
 	err := schema(cmd, []string{})
 	assert.NoError(t, err)
 
@@ -35,11 +37,8 @@ func Test_schema(t *testing.T) {
 
 	contentAIModelOutput, err := os.ReadFile("testdata/schema_test/model/custom_ai_model.sql")
 	assert.NoError(t, err)
-
-	contentAIModel, err := os.ReadFile("testdata/schema_test/migrations/000002_register_vertex_ai_model.sql")
-	assert.NoError(t, err)
-
-	assert.Contains(t, string(contentAIModelOutput), string(contentAIModel))
+	// replacements have been applied
+	assert.Contains(t, string(contentAIModelOutput), `endpoint = '//aiplatform.googleapis.com/projects/test-project/locations/us-central1/publishers/google/models/my-instance-database-model'`)
 }
 
 func cleanup(t *testing.T) {

--- a/cmd/testdata/schema_test/.gitignore
+++ b/cmd/testdata/schema_test/.gitignore
@@ -1,2 +1,3 @@
 /table/
+/model/
 /schema.sql


### PR DESCRIPTION

Propagates the parameters that configure the default connection placeholders to the schema command so that the default values can be overwritten if desired.

Also enables the placeholder replacement by default.
