### PR TITLE
Fixes for schema dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Flags:
   -h, --help                                 help for wrench
       --instance string                      Cloud Spanner instance name (optional. if not set, will use $SPANNER_INSTANCE_ID value)
       --lock-identifier string               Random identifier used to lock migration operations to a single wrench process. (optional. if not set then it will be generated) (default "58a4394a-19f9-4dbf-880d-20b6cf169d46")
+      --output-dir string                    Output directory for schema files. Falls back to --directory if not set.
       --partitioned-dml-concurrency uint16   Set the concurrency for Partitioned-DML statements. (optional. if not set, will use $WRENCH_PARTITIONED_DML_CONCURRENCY or default to 1) (default 1)
       --project string                       GCP project id (optional. if not set, will use $SPANNER_PROJECT_ID or $GOOGLE_CLOUD_PROJECT value)
       --schema-file string                   Name of schema file (optional. if not set, will use default 'schema.sql' file name)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -33,6 +33,7 @@ const (
 	flagNameInstance              = "instance"
 	flagNameDatabase              = "database"
 	flagNameDirectory             = "directory"
+	flagNameOutputDir             = "output-dir"
 	flagSkipVersions              = "skip-versions"
 	flagNameCreateNoPrompt        = "no-prompt"
 	flagCredentialsFile           = "credentials-file"
@@ -73,6 +74,14 @@ func newSpannerClient(ctx context.Context, c *cobra.Command) (*spanner.Client, e
 	}
 
 	return client, nil
+}
+
+func outputDirPath(c *cobra.Command) string {
+	outDir := c.Flag(flagNameOutputDir).Value.String()
+	if outDir != "" {
+		return outDir
+	}
+	return c.Flag(flagNameDirectory).Value.String()
 }
 
 func schemaFilePath(c *cobra.Command) string {

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -74,7 +74,7 @@ func load(c *cobra.Command, args []string) error {
 		}
 	}
 
-	err = os.WriteFile(schemaFilePath(c), ddl, 0664)
+	err = os.WriteFile(schemaFilePath(c), ddl, 0o644)
 	if err != nil {
 		return &Error{
 			err: err,
@@ -211,13 +211,13 @@ func writeDDL(ddl spanner.SchemaDDL, schemaDir string) error {
 	if err := mkdir(parent); err != nil {
 		return err
 	}
-	return os.WriteFile(file, []byte(ddl.Statement), 0664)
+	return os.WriteFile(file, []byte(ddl.Statement), 0o644)
 }
 
 func mkdir(parent string) error {
 	_, err := os.Stat(parent)
 	if os.IsNotExist(err) {
-		err = os.MkdirAll(parent, 0700)
+		err = os.MkdirAll(parent, 0o755)
 		if err != nil {
 			return err
 		}
@@ -233,26 +233,21 @@ func writeData(data spanner.StaticData, schemaDir string) error {
 	if err := mkdir(parent); err != nil {
 		return err
 	}
-	return os.WriteFile(file, []byte(strings.Join(data.Statements, "\n")), 0644)
+	return os.WriteFile(file, []byte(strings.Join(data.Statements, "\n")), 0o644)
 }
 
 func schemaDirPath(c *cobra.Command) string {
-	return c.Flag(flagNameDirectory).Value.String()
+	return outputDirPath(c)
 }
 
 func clearSchemaDir(c *cobra.Command) error {
-	tables := filepath.Join(schemaDirPath(c), dirTable)
-	indexes := filepath.Join(schemaDirPath(c), dirIndex)
-	staticData := filepath.Join(schemaDirPath(c), dirStaticData)
+	knownObjectTypes := append([]string{dirStaticData}, spanner.AllObjectTypes...)
 
-	if err := os.RemoveAll(tables); err != nil {
-		return err
-	}
-	if err := os.RemoveAll(indexes); err != nil {
-		return err
-	}
-	if err := os.RemoveAll(staticData); err != nil {
-		return err
+	for _, target := range knownObjectTypes {
+		path := filepath.Join(schemaDirPath(c), target)
+		if err := os.RemoveAll(path); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/load_test.go
+++ b/cmd/load_test.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"testing"
 )
 
 func Test_readStaticDataTablesFile(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,7 @@ var (
 	instance                  string
 	database                  string
 	directory                 string
+	outputDir                 string
 	schemaFile                string
 	credentialsFile           string
 	staticDataTablesFile      string
@@ -84,6 +85,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&instance, flagNameInstance, spannerInstanceID(), "Cloud Spanner instance name (optional. if not set, will use $SPANNER_INSTANCE_ID value)")
 	rootCmd.PersistentFlags().StringVar(&database, flagNameDatabase, spannerDatabaseID(), "Cloud Spanner database name (optional. if not set, will use $SPANNER_DATABASE_ID value)")
 	rootCmd.PersistentFlags().StringVar(&directory, flagNameDirectory, "", "Directory that schema file placed (required)")
+	rootCmd.PersistentFlags().StringVar(&outputDir, flagNameOutputDir, "", "Output directory for schema files. Falls back to --directory if not set.")
 	rootCmd.PersistentFlags().StringVar(&schemaFile, flagNameSchemaFile, "", "Name of schema file (optional. if not set, will use default 'schema.sql' file name)")
 	rootCmd.PersistentFlags().StringVar(&credentialsFile, flagCredentialsFile, "", "Specify Credentials File")
 	rootCmd.PersistentFlags().StringVar(&staticDataTablesFile, flagStaticDataTablesFile, "", "File containing list of static data tables to track (optional)")

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/pflag"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/spf13/pflag"
 
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"

--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -60,7 +60,39 @@ const (
 	ExistingMigrationsUpgradeStarted   = UpgradeStatus("Started")
 	ExistingMigrationsUpgradeCompleted = UpgradeStatus("Completed")
 	createUpgradeIndicatorFormatString = `CREATE TABLE %s (Dummy INT64 NOT NULL) PRIMARY KEY(Dummy)`
+
+	ObjectTypeTable         = "table"
+	ObjectTypeView          = "view"
+	ObjectTypeIndex         = "index"
+	ObjectTypeModel         = "model"
+	ObjectTypeChangeStream  = "change_stream"
+	ObjectTypeSequence      = "sequence"
+	ObjectTypeDatabaseRole  = "database_role"
+	ObjectTypeSearchIndex   = "search_index"
+	ObjectTypePropertyGraph = "property_graph"
+	ObjectTypeFunction      = "function"
+	ObjectTypeSchema        = "schema"
+	ObjectTypePlacement     = "placement"
+	ObjectTypeProtoBundle   = "proto_bundle"
+	ObjectTypeSynonym       = "synonym"
 )
+
+var AllObjectTypes = []string{
+	ObjectTypeTable,
+	ObjectTypeView,
+	ObjectTypeIndex,
+	ObjectTypeModel,
+	ObjectTypeChangeStream,
+	ObjectTypeSequence,
+	ObjectTypeDatabaseRole,
+	ObjectTypeSearchIndex,
+	ObjectTypePropertyGraph,
+	ObjectTypeFunction,
+	ObjectTypeSchema,
+	ObjectTypePlacement,
+	ObjectTypeProtoBundle,
+	ObjectTypeSynonym,
+}
 
 var (
 	createUpgradeIndicatorSql = fmt.Sprintf(createUpgradeIndicatorFormatString, upgradeIndicator)
@@ -228,7 +260,7 @@ func parseDDL(statement string) (ddl SchemaDDL, err error) {
 	objectType := strings.ToLower(matches["ObjectType"])
 	// put all indexes in the same group
 	if strings.HasSuffix(objectType, "index") {
-		objectType = "index"
+		objectType = ObjectTypeIndex
 	}
 
 	ddl = SchemaDDL{

--- a/pkg/spanner/dataloader/dataloader.go
+++ b/pkg/spanner/dataloader/dataloader.go
@@ -42,7 +42,6 @@ func RowToInsertStatement(tableName string, row *spanner.Row) (string, error) {
 		tableName,
 		strings.Join(columns.Names, ", "),
 		strings.Join(columns.FormattedValues, ", ")), nil
-
 }
 
 func RowToColumns(row *spanner.Row) (Columns, error) {

--- a/pkg/spanner/migration_test.go
+++ b/pkg/spanner/migration_test.go
@@ -34,13 +34,11 @@ const (
 	TestStmtNonPartitionedDML = "DELETE FROM Singers WHERE SingerId NOT IN (SELECT SingerId FROM Concerts)"
 )
 
-var (
-	TestPlaceholders = map[string]string{
-		"PROJECT_ID":  "projectID134",
-		"INSTANCE_ID": "instanceID456",
-		"DATABASE_ID": "databaseID789",
-	}
-)
+var TestPlaceholders = map[string]string{
+	"PROJECT_ID":  "projectID134",
+	"INSTANCE_ID": "instanceID456",
+	"DATABASE_ID": "databaseID789",
+}
 
 func TestLoadMigrations(t *testing.T) {
 	ms, err := LoadMigrations(filepath.Join("testdata", "migrations"), nil, false, PlaceholderOptions{})
@@ -935,7 +933,8 @@ SELECT 1 FROM Foo
 /* this is not preamble */`,
 			want: `block 1
 block 2
-block 3`},
+block 3`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## WHAT

<!--
Write the change being made with this pull request
-->

Some fixes for schema command.

- Add flag to specify a different output directory, so that definitions can be placed elsewhere.
- Update the definitions cleanup to only delete folders that wrench creates, and work with output dir flag
- File / folder permissions
