### PR TITLE
repeatable migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,19 @@ This is a fork of https://github.com/cloudspannerecosystem/wrench with the follo
 - Repair dirty migrations. If a migration fails the version is marked as dirty. Any partial changes should be reverted manually and the history cleaned
 using `migrate repair`.
 
+- Repeatable Migrations. Migrations prefixed with `R__` (case-insensitive) followed by a name (e.g. `R__create_view.sql`) will be executed whenever their content changes (detected via checksum).
+  The name can contain alphanumeric characters, underscores and dashes.
+  They are executed after all versioned migrations have been applied.
+  **Note:** Repeatable migrations must be idempotent (e.g. `CREATE OR REPLACE VIEW`) as they may be re-executed multiple times and are not atomic with the history update.
+
+
 ## Onboarding existing databases to wrench
 
-This fork of wrench uses two additional tables for tracking migrations, `SchemaMigrationsHistory` for all scripts
-applied and `SchemaMigrationsLock` to limit wrench migrations to a single invocation.
+This fork of wrench uses three additional tables for tracking migrations:
+- `SchemaMigrationsHistory` for all versioned scripts applied.
+- `SchemaMigrationsRepeatableHistory` for tracking repeatable migrations and their checksums.
+- `SchemaMigrationsLock` to limit wrench migrations to a single invocation.
+
 If coming from a database managed by `golang-migrate` or the `cloudspannerecosystem/wrench` then you will already have a
 `SchemaMigrations` table and no work is needed. You can proceed to use this version of wrench and during the next migration
 it will detect that the `SchemaMigrationsHistory` table is missing, then create and backfill the "history" data.
@@ -31,7 +40,7 @@ If you have an existing database that is not controlled by any migration tools t
 databases but recreating for new databases.
 
 ### If you wish to go back to `golang-migrate` or `cloudspannerecosystem/wrench`
-You can simply drop the `SchemaMigrationsHistory` and `SchemaMigrationsLock` table as the `SchemaMigrations` will be in sync.
+You can simply drop the `SchemaMigrationsHistory`, `SchemaMigrationsRepeatableHistory` and `SchemaMigrationsLock` tables as the `SchemaMigrations` will be in sync.
 ___
 
 ## Installation

--- a/cmd/load_test.go
+++ b/cmd/load_test.go
@@ -124,4 +124,3 @@ func Test_writeDDL(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/core/migrate.go
+++ b/pkg/core/migrate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"os"
 	"path/filepath"
@@ -33,9 +34,16 @@ func CreateMigrationFile(dir string, name string, opts ...MigrationSequenceOpt) 
 		return "", err
 	}
 
+	var versionedMigrations spanner.Migrations
+	for _, m := range ms {
+		if !m.IsRepeatable {
+			versionedMigrations = append(versionedMigrations, m)
+		}
+	}
+
 	var v uint = 1
-	if len(ms) > 0 {
-		v = roundNext(ms[len(ms)-1].Version, options.Interval)
+	if len(versionedMigrations) > 0 {
+		v = roundNext(versionedMigrations[len(versionedMigrations)-1].Version, options.Interval)
 	}
 
 	vStr := fmt.Sprintf("%0*d", options.ZeroPrefixLength, v)
@@ -83,6 +91,15 @@ func MigrateUp(ctx context.Context, client *spanner.Client, migrationsDir string
 		return err
 	}
 
+	var versionedMigrations, repeatableMigrations spanner.Migrations
+	for _, m := range migrations {
+		if m.IsRepeatable {
+			repeatableMigrations = append(repeatableMigrations, m)
+		} else {
+			versionedMigrations = append(versionedMigrations, m)
+		}
+	}
+
 	if err = client.EnsureMigrationTable(ctx, options.VersionTableName); err != nil {
 		return err
 	}
@@ -92,21 +109,36 @@ func MigrateUp(ctx context.Context, client *spanner.Client, migrationsDir string
 		return err
 	}
 
-	var migrationsOutput spanner.MigrationsOutput
+	migrationsOutput := make(spanner.MigrationsOutput)
 	switch status {
 	case spanner.ExistingMigrationsUpgradeStarted:
-		migrationsOutput, err = client.UpgradeExecuteMigrations(ctx, migrations, options.Limit, options.VersionTableName, options.ProtoDescriptors, options.FFMigrations)
+		output, err := client.UpgradeExecuteMigrations(ctx, versionedMigrations, options.Limit, options.VersionTableName, options.ProtoDescriptors, options.FFMigrations)
 		if err != nil {
 			return err
 		}
+		maps.Copy(migrationsOutput, output)
 	case spanner.ExistingMigrationsUpgradeCompleted:
-		migrationsOutput, err = client.ExecuteMigrations(ctx, migrations, options.Limit, options.VersionTableName, options.PartitionedDMLConcurrency, options.ProtoDescriptors, options.FFMigrations)
+		output, err := client.ExecuteMigrations(ctx, versionedMigrations, options.Limit, options.VersionTableName, options.PartitionedDMLConcurrency, options.ProtoDescriptors, options.FFMigrations)
 		if err != nil {
 			return err
 		}
+		maps.Copy(migrationsOutput, output)
 	default:
 		return errors.New("migration in undetermined state")
 	}
+
+	if len(repeatableMigrations) > 0 {
+		repeatableTableName := spanner.RepeatableHistoryTableName(options.VersionTableName)
+		if err := client.EnsureRepeatableMigrationTable(ctx, repeatableTableName); err != nil {
+			return err
+		}
+		repeatableOutput, err := client.ExecuteRepeatableMigrations(ctx, repeatableMigrations, repeatableTableName, options.PartitionedDMLConcurrency, options.ProtoDescriptors)
+		if err != nil {
+			return err
+		}
+		maps.Copy(migrationsOutput, repeatableOutput)
+	}
+
 	if options.PrintRowsAffected {
 		fmt.Print(migrationsOutput.String())
 	}
@@ -147,6 +179,26 @@ func MigrateHistory(ctx context.Context, client *spanner.Client, opts ...Migrate
 		_, _ = fmt.Fprintf(writer, "%d\t%v\t%v\t%v\n", h.Version, h.Dirty, h.Created, h.Modified)
 	}
 	_ = writer.Flush()
+
+	repeatableHistory, err := client.GetRepeatableMigrationHistory(ctx, spanner.RepeatableHistoryTableName(options.VersionTableName))
+	if err != nil {
+		return err
+	}
+	if len(repeatableHistory) > 0 {
+		sort.SliceStable(repeatableHistory, func(i, j int) bool {
+			return repeatableHistory[i].AppliedAt.Before(repeatableHistory[j].AppliedAt)
+		})
+
+		_, _ = fmt.Fprintln(os.Stdout)
+		writer = tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', tabwriter.AlignRight)
+		_, _ = fmt.Fprintln(writer, "Repeatable Name\tChecksum\tApplied At")
+		for i := range repeatableHistory {
+			h := repeatableHistory[i]
+			_, _ = fmt.Fprintf(writer, "%s\t%.8s\t%v\n", h.Name, h.Checksum, h.AppliedAt)
+		}
+		_ = writer.Flush()
+	}
+
 	return nil
 }
 

--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -54,6 +54,7 @@ const (
 	ddlStatementsSeparator             = ";"
 	upgradeIndicator                   = "wrench_upgrade_indicator"
 	historyStr                         = "History"
+	repeatableHistoryStr               = "RepeatableHistory"
 	lockStr                            = "Lock"
 	FirstRun                           = UpgradeStatus("FirstRun")
 	ExistingMigrationsNoUpgrade        = UpgradeStatus("NoUpgrade")
@@ -113,6 +114,16 @@ type MigrationHistoryRecord struct {
 	Dirty    bool      `spanner:"Dirty"`
 	Created  time.Time `spanner:"Created"`
 	Modified time.Time `spanner:"Modified"`
+}
+
+type RepeatableMigrationHistoryRecord struct {
+	Name      string    `spanner:"Name"`
+	Checksum  string    `spanner:"Checksum"`
+	AppliedAt time.Time `spanner:"AppliedAt"`
+}
+
+func RepeatableHistoryTableName(versionTableName string) string {
+	return versionTableName + repeatableHistoryStr
 }
 
 func NewClient(ctx context.Context, config *Config) (*Client, error) {
@@ -833,6 +844,29 @@ func (c *Client) GetMigrationHistory(ctx context.Context, versionTableName strin
 	return history, nil
 }
 
+func (c *Client) GetRepeatableMigrationHistory(ctx context.Context, tableName string) ([]RepeatableMigrationHistoryRecord, error) {
+	if !c.tableExists(ctx, tableName) {
+		return nil, nil
+	}
+
+	history := make([]RepeatableMigrationHistoryRecord, 0)
+	stmt := spanner.NewStatement("SELECT Name, Checksum, AppliedAt FROM " + tableName)
+	err := c.spannerClient.Single().Query(ctx, stmt).Do(func(r *spanner.Row) error {
+		record := RepeatableMigrationHistoryRecord{}
+		if err := r.ToStruct(&record); err != nil {
+			return err
+		}
+		history = append(history, record)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return history, nil
+}
+
 type MigrationsOutput map[string]migrationInfo
 
 type migrationInfo struct {
@@ -991,6 +1025,99 @@ func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, l
 
 	if count == 0 {
 		fmt.Println("no change")
+	}
+
+	return migrationsOutput, nil
+}
+
+func (c *Client) ExecuteRepeatableMigrations(ctx context.Context, migrations Migrations, tableName string, partitionedConcurrency int, protoDescriptors []byte) (MigrationsOutput, error) {
+	if len(migrations) == 0 {
+		return nil, nil
+	}
+
+	for _, m := range migrations {
+		if !m.IsRepeatable {
+			return nil, &Error{
+				Code: ErrorCodeExecuteMigrations,
+				err:  fmt.Errorf("migration %s is not a repeatable migration", m.FileName),
+			}
+		}
+	}
+
+	history, err := c.GetRepeatableMigrationHistory(ctx, tableName)
+	if err != nil {
+		return nil, &Error{
+			Code: ErrorCodeExecuteMigrations,
+			err:  err,
+		}
+	}
+	applied := make(map[string]string, len(history))
+	for _, h := range history {
+		applied[h.Name] = h.Checksum
+	}
+
+	migrationsOutput := make(MigrationsOutput)
+	for _, m := range migrations {
+		if appliedChecksum, ok := applied[m.Name]; ok && appliedChecksum == m.Checksum {
+			continue
+		}
+
+		statementKind := cmp.Or(m.Directives.StatementKind, m.Kind)
+		var rowsAffected int64
+		switch statementKind {
+		case StatementKindDDL:
+			if err := c.ApplyDDL(ctx, m.Statements, protoDescriptors); err != nil {
+				return nil, &Error{
+					Code: ErrorCodeExecuteMigrations,
+					err:  err,
+				}
+			}
+		case StatementKindDML:
+			count, err := c.ApplyDML(ctx, m.Statements)
+			if err != nil {
+				return nil, &Error{
+					Code: ErrorCodeExecuteMigrations,
+					err:  err,
+				}
+			}
+			rowsAffected = count
+		case StatementKindPartitionedDML:
+			count, err := c.ApplyPartitionedDML(ctx, m.Statements, partitionedConcurrency)
+			if err != nil {
+				return nil, &Error{
+					Code: ErrorCodeExecuteMigrations,
+					err:  err,
+				}
+			}
+			rowsAffected = count
+		case StatementKindConvergentDML:
+			count, err := convergentApply(ctx, c.ApplyDML, m.Statements, m.Directives.Concurrency)
+			if err != nil {
+				return nil, &Error{
+					Code: ErrorCodeExecuteMigrations,
+					err:  err,
+				}
+			}
+			rowsAffected = count
+		default:
+			return nil, &Error{
+				Code: ErrorCodeExecuteMigrations,
+				err:  fmt.Errorf("Unknown query type, repeatable migration: %s", m.FileName),
+			}
+		}
+
+		_, err := c.spannerClient.Apply(ctx, []*spanner.Mutation{
+			spanner.InsertOrUpdate(tableName, []string{"Name", "Checksum", "AppliedAt"}, []interface{}{m.Name, m.Checksum, spanner.CommitTimestamp}),
+		})
+		if err != nil {
+			return nil, &Error{
+				Code: ErrorCodeExecuteMigrations,
+				err:  err,
+			}
+		}
+
+		fmt.Printf("R/up %s\n", m.Name)
+		migrationsOutput[m.FileName] = migrationInfo{RowsAffected: rowsAffected}
 	}
 
 	return migrationsOutput, nil
@@ -1396,6 +1523,20 @@ func (c *Client) EnsureMigrationTable(ctx context.Context, tableName string) err
 	}
 
 	return nil
+}
+
+func (c *Client) EnsureRepeatableMigrationTable(ctx context.Context, tableName string) error {
+	if c.tableExists(ctx, tableName) {
+		return nil
+	}
+
+	stmt := fmt.Sprintf(`CREATE TABLE %s (
+		Name STRING(MAX) NOT NULL,
+		Checksum STRING(64) NOT NULL,
+		AppliedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+	) PRIMARY KEY(Name)`, tableName)
+
+	return c.ApplyDDL(ctx, []string{stmt}, nil)
 }
 
 func (c *Client) DetermineUpgradeStatus(ctx context.Context, tableName string) (UpgradeStatus, error) {

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -100,6 +100,101 @@ func TestLoadDDL(t *testing.T) {
 	}
 }
 
+func TestExecuteRepeatableMigrations(t *testing.T) {
+	ctx := context.Background()
+
+	client, done := testClientWithDatabase(t, ctx)
+	defer done()
+
+	repeatableTableName := "RepeatableHistory"
+	err := client.EnsureRepeatableMigrationTable(ctx, repeatableTableName)
+	require.NoError(t, err)
+
+	migrations := Migrations{
+		{
+			Name:         "create_view",
+			FileName:     "R__create_view.sql",
+			IsRepeatable: true,
+			Statements:   []string{"CREATE VIEW SingerNames SQL SECURITY INVOKER AS SELECT 1 AS Col1"},
+			Checksum:     "hash1",
+			Kind:         StatementKindDDL,
+		},
+	}
+
+	// 1. Initial execution
+	output, err := client.ExecuteRepeatableMigrations(ctx, migrations, repeatableTableName, 1, nil)
+	require.NoError(t, err)
+	assert.Len(t, output, 1)
+	assert.Contains(t, output, "R__create_view.sql")
+
+	// 2. Second execution with same checksum should be skipped
+	output, err = client.ExecuteRepeatableMigrations(ctx, migrations, repeatableTableName, 1, nil)
+	require.NoError(t, err)
+	assert.Empty(t, output)
+
+	// 3. Execution with different checksum should run again
+	migrations[0].Checksum = "hash2"
+	migrations[0].Statements = []string{"CREATE OR REPLACE VIEW SingerNames SQL SECURITY INVOKER AS SELECT 2 AS Col1"}
+	output, err = client.ExecuteRepeatableMigrations(ctx, migrations, repeatableTableName, 1, nil)
+	require.NoError(t, err)
+	assert.Len(t, output, 1)
+
+	// 4. Verify that it errors if a non-repeatable migration is passed
+	nonRepeatable := Migrations{
+		{
+			Version:      1,
+			FileName:     "001.sql",
+			IsRepeatable: false,
+		},
+	}
+	_, err = client.ExecuteRepeatableMigrations(ctx, nonRepeatable, repeatableTableName, 1, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "is not a repeatable migration")
+}
+
+func TestExecuteRepeatableMigrations_EndToEnd(t *testing.T) {
+	ctx := context.Background()
+
+	client, done := testClientWithDatabase(t, ctx)
+	defer done()
+
+	repeatableTableName := "RepeatableHistoryEndToEnd"
+	err := client.EnsureRepeatableMigrationTable(ctx, repeatableTableName)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+
+	// 1. Initial run
+	migrationFile := filepath.Join(dir, "R__view.sql")
+	content1 := "CREATE VIEW MyView SQL SECURITY INVOKER AS SELECT 1 AS Col1"
+	require.NoError(t, os.WriteFile(migrationFile, []byte(content1), 0o644))
+
+	ms, err := LoadMigrations(dir, nil, false, PlaceholderOptions{})
+	require.NoError(t, err)
+	require.Len(t, ms, 1)
+
+	output, err := client.ExecuteRepeatableMigrations(ctx, ms, repeatableTableName, 1, nil)
+	require.NoError(t, err)
+	assert.Len(t, output, 1)
+
+	// 2. Second run (no change)
+	ms, err = LoadMigrations(dir, nil, false, PlaceholderOptions{})
+	require.NoError(t, err)
+	output, err = client.ExecuteRepeatableMigrations(ctx, ms, repeatableTableName, 1, nil)
+	require.NoError(t, err)
+	assert.Empty(t, output)
+
+	// 3. Third run (content changed)
+	content2 := "CREATE OR REPLACE VIEW MyView SQL SECURITY INVOKER AS SELECT 2 AS Col1"
+	require.NoError(t, os.WriteFile(migrationFile, []byte(content2), 0o644))
+
+	ms, err = LoadMigrations(dir, nil, false, PlaceholderOptions{})
+	require.NoError(t, err)
+	output, err = client.ExecuteRepeatableMigrations(ctx, ms, repeatableTableName, 1, nil)
+	require.NoError(t, err)
+	assert.Len(t, output, 1)
+}
+
 func TestApplyDDLFile(t *testing.T) {
 	ctx := context.Background()
 
@@ -392,6 +487,31 @@ func ensureMigrationColumn(t *testing.T, ctx context.Context, client *Client, co
 	if want, got := isNullable, c.IsNullable; want != got {
 		t.Errorf("want %s, but got %s", want, got)
 	}
+}
+
+func TestGetRepeatableMigrationHistory(t *testing.T) {
+	ctx := context.Background()
+
+	client, done := testClientWithDatabase(t, ctx)
+	defer done()
+
+	repeatableTableName := "RepeatableHistory"
+	err := client.EnsureRepeatableMigrationTable(ctx, repeatableTableName)
+	require.NoError(t, err)
+
+	checksum := "abc123def"
+	name := "my_view"
+	_, err = client.spannerClient.Apply(ctx, []*spanner.Mutation{
+		spanner.InsertOrUpdate(repeatableTableName, []string{"Name", "Checksum", "AppliedAt"}, []interface{}{name, checksum, spanner.CommitTimestamp}),
+	})
+	require.NoError(t, err)
+
+	history, err := client.GetRepeatableMigrationHistory(ctx, repeatableTableName)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, name, history[0].Name)
+	assert.Equal(t, checksum, history[0].Checksum)
+	assert.False(t, history[0].AppliedAt.IsZero())
 }
 
 func ensureMigrationHistoryRecord(t *testing.T, ctx context.Context, client *Client, version int64, dirty bool) {

--- a/pkg/spanner/migration.go
+++ b/pkg/spanner/migration.go
@@ -20,6 +20,8 @@
 package spanner
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -43,6 +45,9 @@ var (
 	// 001_name.up.sql
 	// 001_name.generated.sql
 	migrationFileRegex = regexp.MustCompile(`^([0-9]+)(?:_([a-zA-Z0-9_\-]+))?(?:[.]up|[.]generated)?\.sql$`)
+
+	// repeatableMigrationRegex matches patterns like R__name.sql
+	repeatableMigrationRegex = regexp.MustCompile(`(?i)^R__([a-zA-Z0-9_\-]+)\.sql$`)
 
 	MigrationNameRegex = regexp.MustCompile(`[a-zA-Z0-9_\-]+`)
 
@@ -86,6 +91,10 @@ type (
 
 		// Directives defines config scoped to a single migration.
 		Directives MigrationDirectives
+
+		IsRepeatable bool
+
+		Checksum string
 	}
 
 	// MigrationDirectives configures how the migration should be executed.
@@ -120,6 +129,12 @@ func (ms Migrations) Swap(i, j int) {
 }
 
 func (ms Migrations) Less(i, j int) bool {
+	if ms[i].IsRepeatable != ms[j].IsRepeatable {
+		return !ms[i].IsRepeatable
+	}
+	if ms[i].IsRepeatable {
+		return ms[i].Name < ms[j].Name
+	}
 	return ms[i].Version < ms[j].Version
 }
 
@@ -140,17 +155,27 @@ func LoadMigrations(dir string, toSkipSlice []uint, detectPartitionedDML bool, p
 			continue
 		}
 
-		matches := migrationFileRegex.FindStringSubmatch(f.Name())
-		if matches == nil {
-			continue
-		}
+		var version uint64
+		var name string
+		var isRepeatable bool
 
-		version, err := strconv.ParseUint(matches[1], 10, 64)
-		if err != nil {
-			continue
-		}
-
-		if toSkipMap[version] {
+		if matches := migrationFileRegex.FindStringSubmatch(f.Name()); matches != nil {
+			v, err := strconv.ParseUint(matches[1], 10, 64)
+			if err != nil {
+				continue
+			}
+			if v == 0 {
+				return nil, fmt.Errorf("migration %s has invalid version 0; versioned migrations must start at 1", f.Name())
+			}
+			if toSkipMap[v] {
+				continue
+			}
+			version = v
+			name = matches[2]
+		} else if matches := repeatableMigrationRegex.FindStringSubmatch(f.Name()); matches != nil {
+			isRepeatable = true
+			name = matches[1]
+		} else {
 			continue
 		}
 
@@ -182,19 +207,37 @@ func LoadMigrations(dir string, toSkipSlice []uint, detectPartitionedDML bool, p
 			return nil, err
 		}
 
+		hash := sha256.New()
+		for _, stmt := range statements {
+			// Normalize line endings to LF to ensure consistent checksums across platforms
+			normalized := strings.ReplaceAll(stmt, "\r\n", "\n")
+			hash.Write([]byte(normalized))
+		}
+		checksum := hex.EncodeToString(hash.Sum(nil))
+
 		migrations = append(migrations, &Migration{
-			Version:    uint(version),
-			Name:       matches[2],
-			FileName:   f.Name(),
-			Statements: statements,
-			Kind:       kind,
-			Directives: directives,
+			Version:      uint(version),
+			Name:         name,
+			FileName:     f.Name(),
+			Statements:   statements,
+			Kind:         kind,
+			Directives:   directives,
+			IsRepeatable: isRepeatable,
+			Checksum:     checksum,
 		})
 	}
 
 	sort.Sort(migrations)
 	seen := map[uint]*Migration{}
+	seenRepeatable := map[string]*Migration{}
 	for _, m := range migrations {
+		if m.IsRepeatable {
+			if dupe, got := seenRepeatable[m.Name]; got {
+				return nil, fmt.Errorf("repeatable migration %s has a duplicate name in file %s", m.Name, dupe.FileName)
+			}
+			seenRepeatable[m.Name] = m
+			continue
+		}
 		if dupe, got := seen[m.Version]; got {
 			return nil, fmt.Errorf("migration %d %s has a duplicate version number of %s", m.Version, m.Name, dupe.Name)
 		}

--- a/pkg/spanner/migration_test.go
+++ b/pkg/spanner/migration_test.go
@@ -21,10 +21,12 @@ package spanner
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -373,6 +375,37 @@ func Test_migrationFileRegex(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			matches := migrationFileRegex.FindStringSubmatch(tc.input)
+			assert.Equal(t, tc.expected, matches)
+		})
+	}
+}
+
+func Test_repeatableMigrationRegex(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected []string
+	}{
+		"Uppercase": {
+			input:    "R__name.sql",
+			expected: []string{"R__name.sql", "name"},
+		},
+		"Lowercase": {
+			input:    "r__name.sql",
+			expected: []string{"r__name.sql", "name"},
+		},
+		"MixedWithDashesAndUnderscores": {
+			input:    "r__My-Name_123.sql",
+			expected: []string{"r__My-Name_123.sql", "My-Name_123"},
+		},
+		"NoMatchVersioned": {
+			input:    "001_name.sql",
+			expected: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			matches := repeatableMigrationRegex.FindStringSubmatch(tc.input)
 			assert.Equal(t, tc.expected, matches)
 		})
 	}
@@ -1021,4 +1054,78 @@ block 3`,
 			assert.Equal(t, tt.want, extractPreamble(tt.data))
 		})
 	}
+}
+
+func TestLoadMigrationsRejectsVersionZero(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "0_initial.sql"), []byte("SELECT 1;"), 0o644))
+
+	_, err := LoadMigrations(dir, nil, false, PlaceholderOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid version 0")
+}
+
+func TestLoadMigrationsRepeatable(t *testing.T) {
+	dir := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "100_standard.sql"), []byte("SELECT 1;"), 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "R__create_view.sql"), []byte("CREATE VIEW SingerNames AS SELECT FirstName, LastName FROM Singers;"), 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "R__another.sql"), []byte("SELECT 2;"), 0o644))
+
+	ms, err := LoadMigrations(dir, nil, false, PlaceholderOptions{})
+	assert.NoError(t, err)
+	assert.Len(t, ms, 3)
+
+	// 100_standard.sql should be first (versioned)
+	assert.Equal(t, uint(100), ms[0].Version)
+	assert.False(t, ms[0].IsRepeatable)
+
+	// Repeatable migrations should follow, sorted by name
+	assert.Equal(t, "another", ms[1].Name)
+	assert.True(t, ms[1].IsRepeatable)
+
+	assert.Equal(t, "create_view", ms[2].Name)
+	assert.True(t, ms[2].IsRepeatable)
+
+	// Verify checksum
+	assert.NotEmpty(t, ms[2].Checksum)
+}
+
+func TestLoadMigrationsSorting(t *testing.T) {
+	dir := t.TempDir()
+	// Mix of versioned and repeatable
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "002_second.sql"), []byte("SELECT 2;"), 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "001_first.sql"), []byte("SELECT 1;"), 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "R__b.sql"), []byte("SELECT 'b';"), 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "R__a.sql"), []byte("SELECT 'a';"), 0o644))
+
+	ms, err := LoadMigrations(dir, nil, false, PlaceholderOptions{})
+	assert.NoError(t, err)
+	require.Len(t, ms, 4)
+
+	// Sort order should be:
+	// 1. 001_first.sql
+	// 2. 002_second.sql
+	// 3. R__a.sql
+	// 4. R__b.sql
+	assert.Equal(t, uint(1), ms[0].Version)
+	assert.Equal(t, uint(2), ms[1].Version)
+	assert.Equal(t, "a", ms[2].Name)
+	assert.Equal(t, "b", ms[3].Name)
+}
+
+func TestLoadMigrationsRepeatableLineEndings(t *testing.T) {
+	dir := t.TempDir()
+
+	contentLF := "CREATE VIEW SingerNames AS SELECT FirstName, LastName FROM Singers;\n"
+	contentCRLF := "CREATE VIEW SingerNames AS SELECT FirstName, LastName FROM Singers;\r\n"
+
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "R__view.sql"), []byte(contentLF), 0o644))
+	msLF, err := LoadMigrations(dir, nil, false, PlaceholderOptions{})
+	assert.NoError(t, err)
+
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "R__view.sql"), []byte(contentCRLF), 0o644))
+	msCRLF, err := LoadMigrations(dir, nil, false, PlaceholderOptions{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, msLF[0].Checksum, msCRLF[0].Checksum, "checksums should be equal regardless of line endings")
 }


### PR DESCRIPTION

This PR introduces repeatable migrations to the wrench Spanner migration tool. Unlike versioned migrations that run once in a specific order, repeatable migrations are executed whenever
  their content changes, making them ideal for managing idempotent schema objects like views, indexes, and certain DML operations.

### Key Features
   * Naming Convention: Migrations prefixed with R__ or r__ (e.g., R__create_view.sql) are identified as repeatable.
   * Change Detection: Uses SHA-256 checksums to detect content changes. Checksums are normalized for line endings (LF) to ensure consistency across Windows, Mac, and Linux.
   * Execution Order: Always executed after all pending versioned migrations have been successfully applied.
   * Tracking: History is stored in a dedicated table (default: SchemaMigrationsRepeatableHistory), recording the migration name, checksum, and application timestamp.
   * Idempotency: Requires scripts to be idempotent (e.g., CREATE OR REPLACE VIEW) as they may be re-executed multiple times.

### Improvements & Fixes Included
   * Versioning Integrity: Fixed a regression where wrench migrate create would incorrectly reset the version sequence to 1 if repeatable migrations were present in the directory.
   * Cross-Platform Consistency: Implemented internal line-ending normalization to prevent checksum "flapping" across different operating systems.
   * Enhanced UX: Consolidated migration output to provide a single "no change" message only when both versioned and repeatable paths have no work to do.
   * Stricter Validation: Added duplicate name detection and error handling for unrecognized statement kinds within the repeatable migration path.
   * Expanded Testing: Added comprehensive unit tests for naming/sorting and an end-to-end integration test verifying the full lifecycle from disk to Spanner.

