### PR TITLE
Allow .generated suffix in repeatable migration filenames

### DIFF
--- a/pkg/spanner/migration.go
+++ b/pkg/spanner/migration.go
@@ -46,8 +46,10 @@ var (
 	// 001_name.generated.sql
 	migrationFileRegex = regexp.MustCompile(`^([0-9]+)(?:_([a-zA-Z0-9_\-]+))?(?:[.]up|[.]generated)?\.sql$`)
 
-	// repeatableMigrationRegex matches patterns like R__name.sql
-	repeatableMigrationRegex = regexp.MustCompile(`(?i)^R__([a-zA-Z0-9_\-]+)\.sql$`)
+	// repeatableMigrationRegex matches the following patterns
+	// R__name.sql
+	// R__name.generated.sql
+	repeatableMigrationRegex = regexp.MustCompile(`(?i)^R__([a-zA-Z0-9_\-]+)(?:[.]generated)?\.sql$`)
 
 	MigrationNameRegex = regexp.MustCompile(`[a-zA-Z0-9_\-]+`)
 

--- a/pkg/spanner/migration_test.go
+++ b/pkg/spanner/migration_test.go
@@ -397,6 +397,10 @@ func Test_repeatableMigrationRegex(t *testing.T) {
 			input:    "r__My-Name_123.sql",
 			expected: []string{"r__My-Name_123.sql", "My-Name_123"},
 		},
+		"GeneratedSuffix": {
+			input:    "R__000010_my-name.generated.sql",
+			expected: []string{"R__000010_my-name.generated.sql", "000010_my-name"},
+		},
 		"NoMatchVersioned": {
 			input:    "001_name.sql",
 			expected: nil,


### PR DESCRIPTION
## WHAT

Allow an optional `.generated` suffix in repeatable migration filenames (e.g. `R__my-view.generated.sql`), following the same pattern already used by `migrationFileRegex` for versioned migrations.

## WHY

Repeatable migration files are sometimes auto-generated by tooling, with `.generated.sql` being a common extension. This is also an extension already expected by regular migrations.

Without this change, wrench silently ignores these files since the filename does not match the regex, leaving the `SchemaMigrationsRepeatableHistory` table uncreated and the migrations unapplied.